### PR TITLE
Backwards compatibility for spatial database filtering

### DIFF
--- a/experiment-PIT/public/data/process_311.ts
+++ b/experiment-PIT/public/data/process_311.ts
@@ -16,7 +16,7 @@ interface GeoJSONFeature {
 export const process311Data = async () => {
     try {
          //loading 
-        const request_data = await get311Data();
+        const request_data = await get311Data(undefined, undefined, true);
         const request_geojson = { type: "FeatureCollection", features: [] as GeoJSONFeature[] }; //defining type of array
 
         //converting to geojson

--- a/experiment-PIT/public/data/process_911.ts
+++ b/experiment-PIT/public/data/process_911.ts
@@ -17,7 +17,7 @@ export const processShotsData = async () => {
    
     try {
          //loading 
-        const shots_data = await getShotsData();
+        const shots_data = await getShotsData(undefined, true);
         const shots_geojson = { type: "FeatureCollection", features: [] as GeoJSONFeature[] }; //defining type of array
 
         //converting to GeoJSON

--- a/experiment-PIT/src/api/api.ts
+++ b/experiment-PIT/src/api/api.ts
@@ -6,8 +6,8 @@ const header = {
     "Content-Type": "application/json",
   }
 
-export async function sendChatMessage(message: string, history: Message[]) {
-  const url = `${import.meta.env.VITE_BASE_URL}/chat?request=experiment_pit&app_version=0.7.0&structured_response=False`
+export async function sendChatMessage(message: string, history: Message[], is_spatial: boolean = false) {
+  const url = `${import.meta.env.VITE_BASE_URL}/chat?request=experiment_pit&app_version=0.7.0&structured_response=False&is_spatial=${is_spatial ? 'true' : 'false'}`
   
   const formattedHistory = history.map(message => JSON.stringify(message)).join('\n');
   console.log("history: ", formattedHistory);
@@ -43,8 +43,8 @@ export async function sendChatMessage(message: string, history: Message[]) {
   }
 }
 
-export async function getChatSummary(messages: Message[]) {
-  const url = `${import.meta.env.VITE_BASE_URL}/chat/summary?app_version=0.7.0`
+export async function getChatSummary(messages: Message[], is_spatial: boolean = false) {
+  const url = `${import.meta.env.VITE_BASE_URL}/chat/summary?app_version=0.7.0&is_spatial=${is_spatial ? 'true' : 'false'}`
   
   try {
     const response = await axios.post(url, {messages}, {headers: header});
@@ -55,7 +55,7 @@ export async function getChatSummary(messages: Message[]) {
   }
 }
 
-export async function getShotsData(filtered_date?: string){//must make sure it is in correct format
+export async function getShotsData(filtered_date?: string, is_spatial: boolean = false){//must make sure it is in correct format
   const url = `${import.meta.env.VITE_BASE_URL}/data/query`
 
   const params = {
@@ -63,6 +63,7 @@ export async function getShotsData(filtered_date?: string){//must make sure it i
     request: '911_shots_fired',
     output_type:'json',
     date: filtered_date,
+    is_spatial: is_spatial ? 'true' : 'false',
   }
 
   const headers = {
@@ -93,7 +94,7 @@ export async function getShotsData(filtered_date?: string){//must make sure it i
   }
 } 
 
-export async function get311Data(filtered_date?: number, category?: string){
+export async function get311Data(filtered_date?: number, category?: string, is_spatial: boolean = false){
   const url = `${import.meta.env.VITE_BASE_URL}/data/query` //should output type be
   const params = {
     request: '311_by_geo',
@@ -101,6 +102,7 @@ export async function get311Data(filtered_date?: number, category?: string){
     date: filtered_date,
     app_version: '0.7.0',
     output_type: 'stream',
+    is_spatial: is_spatial ? 'true' : 'false', // check for spatial filtering
   }
 
   const headers = {

--- a/experiment-PIT/src/pages/Chat.tsx
+++ b/experiment-PIT/src/pages/Chat.tsx
@@ -54,7 +54,7 @@ function Chat() {
 
     try {
       // Call backend API helper to get AI response
-      const data = await sendChatMessage(userMsg, messages);
+      const data = await sendChatMessage(userMsg, messages, true);
 
       // Append backend response to messages
       if (data.response) {
@@ -87,7 +87,7 @@ function Chat() {
   };
 
   const handleExportSummary = async () => {
-    const summary = await getChatSummary(messages);
+    const summary = await getChatSummary(messages, true);
 
     if (summary === "Summary generation failed.") {
       setSummaryError(true);

--- a/experiment-PIT/src/pages/Map.tsx
+++ b/experiment-PIT/src/pages/Map.tsx
@@ -59,8 +59,8 @@ function Map() {
 
      
     
-      const shots_geojson = await processShotsData();
-      const request_geojson = await process311Data();
+      const shots_geojson = await processShotsData(undefined, true); //loading shots data from api and converting to geojson
+      const request_geojson = await process311Data(undefined, undefined, true); //loading 311 data from api and converting to geojson
 
       mapRef.current.addSource('shots_data', { //takes a while to load entire dataset... hopefully will be better when we get it hyperlocal
         type: 'geojson',

--- a/experiment-PIT/src/pages/Map.tsx
+++ b/experiment-PIT/src/pages/Map.tsx
@@ -64,8 +64,8 @@ function Map() {
         }
       });
     
-      const shots_geojson = await processShotsData(undefined, true); //loading shots data from api and converting to geojson
-      const request_geojson = await process311Data(undefined, undefined, true); //loading 311 data from api and converting to geojson
+      const shots_geojson = await processShotsData(); //loading shots data from api and converting to geojson
+      const request_geojson = await process311Data(); //loading 311 data from api and converting to geojson
 
       mapRef.current.addSource('shots_data', { //takes a while to load entire dataset... hopefully will be better when we get it hyperlocal
         type: 'geojson',


### PR DESCRIPTION
Tasks:
- Updated SQL queries to include optional spatial filtering based on a passed variable
- Integrated spatial filtering into API endpoints
- Updated frontend function calls to request spatial filtering in experiment-PIT explicitly

Note: Spatial filtering is off by default to allow for backwards compatibility with earlier experiments